### PR TITLE
enhancement: add support for user defined current weather conditions

### DIFF
--- a/examples/forecast.py
+++ b/examples/forecast.py
@@ -3,7 +3,7 @@
 import asyncio
 
 from open_meteo import OpenMeteo
-from open_meteo.models import DailyParameters, HourlyParameters
+from open_meteo.models import CurrentParameters, DailyParameters, HourlyParameters
 
 
 async def main() -> None:
@@ -13,6 +13,12 @@ async def main() -> None:
             latitude=52.27,
             longitude=6.87417,
             current_weather=True,
+            current=[
+                CurrentParameters.TEMPERATURE_2M,
+                CurrentParameters.PRECIPITATION,
+                CurrentParameters.IS_DAY,
+                CurrentParameters.WIND_GUSTS_10M,
+            ],
             daily=[
                 DailyParameters.SUNRISE,
                 DailyParameters.SUNSET,

--- a/src/open_meteo/models.py
+++ b/src/open_meteo/models.py
@@ -41,6 +41,31 @@ class TimeFormat(StrEnum):
     UNIXTIME = "unixtime"
 
 
+class CurrentParameters(StrEnum):
+    """Enum to represent the current parameters available."""
+
+    # Air temperature at 2 meters above ground
+    TEMPERATURE_2M = "temperature_2m"
+
+    # Is day or night
+    IS_DAY = "is_day"
+
+    # Precipitation
+    PRECIPITATION = "precipitation"
+
+    # Maximum wind speed
+    WIND_SPEED_10M = "wind_speed_10m"
+
+    # Wind direction
+    WIND_DIRECTION_10M = "wind_direction_10m"
+
+    # Wind gusts at 10 meters above ground
+    WIND_GUSTS_10M = "wind_gusts_10m"
+
+    # WMO numeric weather code
+    WEATHER_CODE = "weather_code"
+
+
 class HourlyParameters(StrEnum):
     """Enum to represent the hourly parameters available."""
 
@@ -354,13 +379,35 @@ class HourlyForecastUnits(DataClassORJSONMixin):
 
 @dataclass
 class CurrentWeather(DataClassORJSONMixin):
-    """Current weather data."""
+    """Default current weather data."""
 
     time: datetime
     temperature: float
     wind_speed: float = field(metadata=field_options(alias="windspeed"))
     wind_direction: int = field(metadata=field_options(alias="winddirection"))
     weather_code: int = field(metadata=field_options(alias="weathercode"))
+
+
+@dataclass
+class Current(DataClassORJSONMixin):
+    """List of current weather data."""
+
+    time: datetime
+    temperature: float | None = field(
+        default=None, metadata=field_options(alias="temperature_2m")
+    )
+    is_day: bool | None = field(default=None)
+    precipitation: float | None = field(default=None)
+    wind_speed: float | None = field(
+        default=None, metadata=field_options(alias="wind_speed_10m")
+    )
+    wind_direction: int | None = field(
+        default=None, metadata=field_options(alias="wind_direction_10m")
+    )
+    wind_gusts: float | None = field(
+        default=None, metadata=field_options(alias="wind_gusts_10m")
+    )
+    weather_code: int | None = field(default=None)
 
 
 @dataclass
@@ -402,6 +449,7 @@ class Forecast(DataClassORJSONMixin):
     longitude: float
     utc_offset_seconds: int
     current_weather: CurrentWeather | None = field(default=None)
+    current: Current | None = field(default=None)
     daily_units: DailyForecastUnits | None = field(default=None)
     daily: DailyForecast | None = field(default=None)
     hourly_units: HourlyForecastUnits | None = field(default=None)

--- a/src/open_meteo/open_meteo.py
+++ b/src/open_meteo/open_meteo.py
@@ -12,6 +12,7 @@ from yarl import URL
 
 from .exceptions import OpenMeteoConnectionError, OpenMeteoError
 from .models import (
+    CurrentParameters,
     DailyParameters,
     Forecast,
     Geocoding,
@@ -105,6 +106,7 @@ class OpenMeteo:
         longitude: float,
         timezone: str = "UTC",
         current_weather: bool = False,
+        current: list[CurrentParameters] | None = None,
         daily: list[DailyParameters] | None = None,
         hourly: list[HourlyParameters] | None = None,
         past_days: int = 0,
@@ -138,6 +140,8 @@ class OpenMeteo:
         """
         url = URL("https://api.open-meteo.com/v1/forecast").with_query(
             current_weather="true" if current_weather else "false",
+            # if curren_weather is set to true the following line will be ignored
+            current=",".join(current) if current is not None else [],
             daily=",".join(daily) if daily is not None else [],
             hourly=",".join(hourly) if hourly is not None else [],
             latitude=latitude,


### PR DESCRIPTION
# Proposed Changes

As `current_weather` in open-meteo has default properties, this pull requests proposes adding support for defining properties that the user wants for current weather conditions. 

Conform to the official open-meteo docs, this proposal offers defining `current` as a list of user defined parameters for more needed values like precipitation, wind gusts etc.

If `current` list is provided, and `current_weather` boolean value is set to `True`, `current` list will be ignored and only pre-defined values will be returned, with `current = None`.

