### PR TITLE
Add support current weather custom variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ pip install open-meteo
 import asyncio
 
 from open_meteo import OpenMeteo
-from open_meteo.models import DailyParameters, HourlyParameters
+from open_meteo.models import CurrentParameters, DailyParameters, HourlyParameters
 
 
 async def main():
@@ -43,7 +43,12 @@ async def main():
         forecast = await open_meteo.forecast(
             latitude=52.27,
             longitude=6.87417,
-            current_weather=True,
+            current_weather=False,
+            current=[
+                CurrentParameters.TEMPERATURE_2M,
+                CurrentParameters.WEATHER_CODE,
+                CurrentParameters.APPARENT_TEMPERATURE,
+            ],
             daily=[
                 DailyParameters.SUNRISE,
                 DailyParameters.SUNSET,

--- a/examples/forecast.py
+++ b/examples/forecast.py
@@ -3,7 +3,7 @@
 import asyncio
 
 from open_meteo import OpenMeteo
-from open_meteo.models import DailyParameters, HourlyParameters
+from open_meteo.models import CurrentParameters, DailyParameters, HourlyParameters
 
 
 async def main() -> None:
@@ -12,7 +12,12 @@ async def main() -> None:
         forecast = await open_meteo.forecast(
             latitude=52.27,
             longitude=6.87417,
-            current_weather=True,
+            current_weather=False,
+            current=[
+                CurrentParameters.TEMPERATURE_2M,
+                CurrentParameters.WEATHER_CODE,
+                CurrentParameters.APPARENT_TEMPERATURE,
+            ],
             daily=[
                 DailyParameters.SUNRISE,
                 DailyParameters.SUNSET,

--- a/src/open_meteo/__init__.py
+++ b/src/open_meteo/__init__.py
@@ -2,6 +2,9 @@
 
 from .exceptions import OpenMeteoConnectionError, OpenMeteoError
 from .models import (
+    Current,
+    CurrentParameters,
+    CurrentUnits,
     CurrentWeather,
     DailyForecast,
     DailyForecastUnits,
@@ -20,6 +23,9 @@ from .models import (
 from .open_meteo import OpenMeteo
 
 __all__ = [
+    "Current",
+    "CurrentUnits",
+    "CurrentParameters",
     "CurrentWeather",
     "DailyForecast",
     "DailyForecastUnits",

--- a/src/open_meteo/models.py
+++ b/src/open_meteo/models.py
@@ -41,6 +41,43 @@ class TimeFormat(StrEnum):
     UNIXTIME = "unixtime"
 
 
+class CurrentParameters(StrEnum):
+    """Enum to represent the current parameters available."""
+
+    # Air temperature at 2 meters above ground
+    APPARENT_TEMPERATURE = "apparent_temperature"
+
+    # Total cloud cover as an area fraction
+    CLOUD_COVER = "cloudcover"
+
+    # Status for is day or night
+    IS_DAY = "is_day"
+
+    # Total precipitation (rain, showers, snow) sum of the preceding hour
+    PRECIPITATION = "precipitation"
+
+    # Atmospheric air pressure reduced to sea level (hPa)
+    PRESSURE_MSL = "pressure_msl"
+
+    # Relative humidity at 2 meters above ground
+    RELATIVE_HUMIDITY_2M = "relativehumidity_2m"
+
+    # Air temperature at 2 meters above ground
+    TEMPERATURE_2M = "temperature_2m"
+
+    # Weather condition as a WMO numeric weather code.
+    WEATHER_CODE = "weathercode"
+
+    # Wind direction at 10 meters above ground
+    WIND_DIRECTION_10M = "winddirection_10m"
+
+    # Gusts at 10 meters above ground as a maximum of the preceding hour
+    WIND_GUSTS_10M = "windgusts_10m"
+
+    # Wind speed at 10 meters above ground.
+    WIND_SPEED_10M = "windspeed_10m"
+
+
 class HourlyParameters(StrEnum):
     """Enum to represent the hourly parameters available."""
 
@@ -171,6 +208,35 @@ class DailyParameters(StrEnum):
 
 
 @dataclass
+class Current(DataClassORJSONMixin):
+    """Current data."""
+
+    time: datetime
+    apparent_temperature: float | None = field(default=None)
+    cloud_cover: int | None = field(
+        default=None, metadata=field_options(alias="cloudcover")
+    )
+    precipitation: float | None = field(default=None)
+    pressure_msl: float | None = field(default=None)
+    relative_humidity_2m: int | None = field(
+        default=None, metadata=field_options(alias="relativehumidity_2m")
+    )
+    temperature_2m: float | None = field(default=None)
+    weather_code: int | None = field(
+        default=None, metadata=field_options(alias="weathercode")
+    )
+    wind_direction_10m: int | None = field(
+        default=None, metadata=field_options(alias="winddirection_10m")
+    )
+    wind_gusts_10m: float | None = field(
+        default=None, metadata=field_options(alias="windgusts_10m")
+    )
+    wind_speed_10m: float | None = field(
+        default=None, metadata=field_options(alias="windspeed_10m")
+    )
+
+
+@dataclass
 class HourlyForecast(DataClassORJSONMixin):
     """Hourly weather data."""
 
@@ -271,6 +337,35 @@ class DailyForecast(DataClassORJSONMixin):
     )
     wind_speed_10m_max: list[float] | None = field(
         default=None, metadata=field_options(alias="windspeed_10m_max")
+    )
+
+
+@dataclass
+class CurrentUnits(DataClassORJSONMixin):
+    """Current data units."""
+
+    apparent_temperature: str | None = field(default=None)
+    cloud_cover: str | None = field(
+        default=None, metadata=field_options(alias="cloudcover")
+    )
+    precipitation: str | None = field(default=None)
+    pressure_msl: str | None = field(default=None)
+    relative_humidity_2m: str | None = field(
+        default=None, metadata=field_options(alias="relativehumidity_2m")
+    )
+    temperature_2m: str | None = field(default=None)
+    time: TimeFormat | None = field(default=None)
+    weather_code: str | None = field(
+        default=None, metadata=field_options(alias="weathercode")
+    )
+    wind_direction_10m: str | None = field(
+        default=None, metadata=field_options(alias="winddirection_10m")
+    )
+    wind_gusts_10m: str | None = field(
+        default=None, metadata=field_options(alias="windgusts_10m")
+    )
+    wind_speed_10m: str | None = field(
+        default=None, metadata=field_options(alias="windspeed_10m")
     )
 
 
@@ -402,6 +497,8 @@ class Forecast(DataClassORJSONMixin):
     longitude: float
     utc_offset_seconds: int
     current_weather: CurrentWeather | None = field(default=None)
+    current_units: CurrentUnits | None = field(default=None)
+    current: Current | None = field(default=None)
     daily_units: DailyForecastUnits | None = field(default=None)
     daily: DailyForecast | None = field(default=None)
     hourly_units: HourlyForecastUnits | None = field(default=None)

--- a/src/open_meteo/open_meteo.py
+++ b/src/open_meteo/open_meteo.py
@@ -12,6 +12,7 @@ from yarl import URL
 
 from .exceptions import OpenMeteoConnectionError, OpenMeteoError
 from .models import (
+    CurrentParameters,
     DailyParameters,
     Forecast,
     Geocoding,
@@ -105,6 +106,7 @@ class OpenMeteo:
         longitude: float,
         timezone: str = "UTC",
         current_weather: bool = False,
+        current: list[CurrentParameters] | None = None,
         daily: list[DailyParameters] | None = None,
         hourly: list[HourlyParameters] | None = None,
         past_days: int = 0,
@@ -120,6 +122,7 @@ class OpenMeteo:
             latitude: Latitude of the location.
             longitude: Longitude of the location.
             current_weather: Include current weather conditions.
+            current: A list of weather variables to query for.
             daily: A list of weather variables to query for.
             hourly: A list of weather variables to query for.
             past_days: If set, yesterdays or the day before yesterdays are also
@@ -138,6 +141,7 @@ class OpenMeteo:
         """
         url = URL("https://api.open-meteo.com/v1/forecast").with_query(
             current_weather="true" if current_weather else "false",
+            current=",".join(current) if current is not None else [],
             daily=",".join(daily) if daily is not None else [],
             hourly=",".join(hourly) if hourly is not None else [],
             latitude=latitude,


### PR DESCRIPTION
# Proposed Changes

> Add support for Current Weather custom variable. I left current_weather boolean to be backward compatible. If it is set to True, the custom variables are ignored.

## Related Issues

> [#660 ](https://github.com/frenck/python-open-meteo/issues/660)